### PR TITLE
Fix engine to exit correctly on Terminate signal (#442)

### DIFF
--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -953,8 +953,9 @@ def main(options, args, engine_class=StdEngine):
         except Terminate:
             syslog.syslog(syslog.LOG_INFO, "engine: Terminating weewx version %s" % weewx.__version__)
             weeutil.weeutil.log_traceback("    ****  ", syslog.LOG_DEBUG)
-            # Reraise the exception (this should cause the program to exit)
-            raise
+            # Reraise the signal (this should cause the program to exit)
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            os.kill(0, signal.SIGTERM)
 
         # Catch any keyboard interrupts and log them
         except KeyboardInterrupt:


### PR DESCRIPTION
Re-send SIGTERM to self after exiting main loop so process exits
with expected exit code.